### PR TITLE
fix(S-STP#orders): unable to send S-STP orders when lmt price is not 0

### DIFF
--- a/SterlingWrapper/Connector.cs
+++ b/SterlingWrapper/Connector.cs
@@ -179,12 +179,21 @@ namespace SterlingWrapper
             int ord = stiOrder.SubmitOrder();
             string ord_id = stiOrder.ClOrderID;
 
+            string status = "0";
+
             if (ord != 0)
             {
+                status = DecodeError(ord);
                 Console.WriteLine("Sterling API ~ Stop Order:" + ord_id + " Error: " + DecodeError(ord));
             }
 
-            return ord_id;
+            string data = String.Format("{0}, {1} {2} {3} {4} status: {5} ordID: {6}", DateTime.Now.ToLongTimeString(), ticker, ord_price, ord_side, ord_route, status, ord_id);
+            WriteLog(data);
+
+            
+            string _return = ord_id + ";" + ord;
+
+            return _return;
         }
 
         public string Sendstoplimit(string account, string ticker, int ord_size, int ord_disp, string ord_route, double stp_price, double lmt_price, string ord_side, string ord_tif)

--- a/SterlingWrapper/Connector.cs
+++ b/SterlingWrapper/Connector.cs
@@ -94,6 +94,7 @@ namespace SterlingWrapper
             if (error == -49) return "Quote Unavailable or Compliance threshold exceeded or quote unavailable";
             if (error == -50) return "Neither last nor Close price available for MKT order";
             if (error == -51) return "Quote Unavailable or Does not meet min average daily volume";
+            if (error == -56) return "Limit price is not set to 0 for S-STP order";
 
             return "Unknown: " + error.ToString();
         }
@@ -171,6 +172,7 @@ namespace SterlingWrapper
             stiOrder.PriceType = SterlingLib.STIPriceTypes.ptSTISvrStp;
             stiOrder.StpPrice = ord_price;
             stiOrder.Display = ord_disp;
+            stiOrder.LmtPrice = 0;
 
 
             stiOrder.ClOrderID = stiOrder.Symbol + stiOrder.Side + "STP" + DateTime.Now.DayOfYear + DateTime.Now.Hour + DateTime.Now.Minute;

--- a/SterlingWrapper/SterlingWrapper.csproj
+++ b/SterlingWrapper/SterlingWrapper.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SterlingWrapper</RootNamespace>
     <AssemblyName>SterlingWrapper</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
## Summary
This PR introduces a fix to the error code `-56` which was not defined in the codebase, upon talking to the Sterling Officials we found out that during a S-STP price if the Limit Price wasn't 0 we will stumble upon the -56 error and hence they suggested to set the Limit Price to 0.

## Steps To Reproduce
Below are the steps to reproducing this issue.

1. Send a limit order
2.  Try sending a Stop (S-STP) order
3. Output: `-56` error code

## Conclusion
When a limit order is sent out the Lmt Price is set to the given value and hence during a SendStop it doesn't reset the LmtPrice and so it proceeds to using the value set before. Causing a `-56` error